### PR TITLE
slightly improve type instability and add a precompile statement

### DIFF
--- a/src/VersionParsing.jl
+++ b/src/VersionParsing.jl
@@ -34,7 +34,7 @@ For example,
 vparse(s::AbstractString) = vparse(String(s))
 
 digits2num(s::AbstractString) = all(isdigit, s) ? parse(Int, s) : s
-splitparts(s::AbstractString) = map(digits2num, filter!(!isempty, split(s, '.')))
+splitparts(s::T) where {T <: AbstractString} = Union{Int, T}[digits2num(x) for x in filter!(!isempty, split(s, '.'))]
 
 function vparse(s_::String)
     s = replace(s_, r"^[^\d]*[^.\d](\.?\d)"=>s"\1") # strip non-numeric prefix
@@ -75,5 +75,11 @@ function vparse(s_::String)
         return VersionNumber(major, minor, patch, pre, build)
     end
 end
+
+function _precompile_()
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+    precompile(Tuple{typeof(VersionParsing.vparse), String})
+end
+_precompile_()
 
 end # module

--- a/src/VersionParsing.jl
+++ b/src/VersionParsing.jl
@@ -76,10 +76,6 @@ function vparse(s_::String)
     end
 end
 
-function _precompile_()
-    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
-    precompile(Tuple{typeof(VersionParsing.vparse), String})
-end
-_precompile_()
+precompile(Tuple{typeof(vparse), String})
 
 end # module


### PR DESCRIPTION
This package showed up in a profile trace I did when some packages where loaded.

Before:

```
julia> @time @eval vparse("v1.0.2");
  0.187844 seconds (371.28 k allocations: 21.236 MiB, 100.73% compilation time)
```

After:

```
julia> @time @eval vparse("v1.0.2");
  0.065536 seconds (4.64 k allocations: 253.828 KiB, 102.06% compilation time)
```